### PR TITLE
Changed method name to be method signature

### DIFF
--- a/nosejob/src/main/java/com/codingrangers/nosejob/models/data/ClassData.java
+++ b/nosejob/src/main/java/com/codingrangers/nosejob/models/data/ClassData.java
@@ -3,9 +3,9 @@ package com.codingrangers.nosejob.models.data;
 import java.util.List;
 
 public interface ClassData extends CodeData {
-	List<String> getMethodNames();
+	List<String> getMethodSignatures();
 
-	MethodData getMethod(String name);
+	MethodData getMethod(String signature);
 
 	List<String> getFieldsNames();
 

--- a/nosejob/src/main/java/com/codingrangers/nosejob/models/data/parsing/ParsedClass.java
+++ b/nosejob/src/main/java/com/codingrangers/nosejob/models/data/parsing/ParsedClass.java
@@ -27,13 +27,13 @@ public class ParsedClass extends ParsedCodeUnit implements ClassData {
     }
 
     @Override
-    public List<String> getMethodNames() {
+    public List<String> getMethodSignatures() {
         return new ArrayList<String>(classMethods.keySet());
     }
 
     @Override
-    public MethodData getMethod(String name) {
-        return classMethods.get(name);
+    public MethodData getMethod(String signature) {
+        return classMethods.get(signature);
     }
 
     @Override

--- a/nosejob/src/main/java/com/codingrangers/nosejob/models/data/parsing/ParsedMethod.java
+++ b/nosejob/src/main/java/com/codingrangers/nosejob/models/data/parsing/ParsedMethod.java
@@ -14,8 +14,9 @@ public class ParsedMethod extends ParsedCodeUnit implements MethodData {
     private List<VariableData> parameters;
     private List<VariableData> localVariables;
 
-    ParsedMethod(ClassData methodClass, String methodName) {
-        super(methodClass.getFullyQualifiedName(), methodName, methodClass.getFilePath());
+    // Name of a method is the signature. getName returns the signature.
+    ParsedMethod(ClassData methodClass, String methodSignature) {
+        super(methodClass.getFullyQualifiedName(), methodSignature, methodClass.getFilePath());
         className = methodClass.getName();
         parameters = new ArrayList<VariableData>();
     }


### PR DESCRIPTION
There would be issues with multiple methods having the same name (method overloading) they way we were doing things. Instead I am now using method signatures to uniquely identify methods.